### PR TITLE
feat: Add SSL configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ local.properties
 *.jar
 *.war
 *.ear
+keystore.jks
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/README.md
+++ b/README.md
@@ -24,3 +24,30 @@ You can additionally register your account, however data will be automatically c
 <i>*when you will check app at Heroku (trial version), it will require about 2 minutes for Heroku containter to startup.<br>
 Leave browser open, do something else, make a cup of coffee or tea, enjoy your time, come back, enjoy app.</i>
 
+## SSL Configuration
+
+To run this application with SSL, you will need to generate a Java KeyStore (JKS) file and set an environment variable for the keystore password.
+
+### 1. Generate the Keystore
+
+Use the following `keytool` command to generate a `keystore.jks` file in the `src/main/resources` directory:
+
+```bash
+keytool -genkeypair -alias flat_manager -keyalg RSA -keysize 2048 -keystore src/main/resources/keystore.jks -validity 3650 -storepass YourPassword -keypass YourPassword -dname "CN=flat_manager, OU=Development, O=Damian Rowinski, L=Warsaw, ST=Mazovia, C=PL"
+```
+
+Replace `YourPassword` with a secure password.
+
+### 2. Set the Environment Variable
+
+Set the `KEYSTORE_PASSWORD` environment variable to the password you used when generating the keystore.
+
+**Linux/macOS:**
+```bash
+export KEYSTORE_PASSWORD=YourPassword
+```
+
+**Windows:**
+```bash
+set KEYSTORE_PASSWORD=YourPassword
+```

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -115,6 +116,22 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.30</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/pl/damianrowinski/flat_manager/config/SecurityConfig.java
+++ b/src/main/java/pl/damianrowinski/flat_manager/config/SecurityConfig.java
@@ -40,7 +40,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .defaultSuccessUrl("/")
                 .and()
                 .logout()
-                .logoutSuccessUrl("/");
+                .logoutSuccessUrl("/")
+                .and()
+                .requiresChannel()
+                .anyRequest()
+                .requiresSecure();
     }
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,3 +32,10 @@ spring.banner.location=banner.txt
 #spring.datasource.password=coderowo
 #spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+#SSL
+server.port=8443
+server.ssl.key-store-type=JKS
+server.ssl.key-store=classpath:keystore.jks
+server.ssl.key-store-password=${KEYSTORE_PASSWORD}
+server.ssl.key-alias=flat_manager


### PR DESCRIPTION
This change adds SSL configuration to the application, enabling HTTPS and ensuring a secure connection. It includes generating a self-signed certificate, configuring the application to use it, and forcing HTTPS redirection. The keystore password is an environment variable to avoid hardcoding secrets.

---
*PR created automatically by Jules for task [864248712271283781](https://jules.google.com/task/864248712271283781) started by @rowinskidamian*