### PR TITLE
Update Dockerfile for Java 21 and enable tests during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Use an official Maven image to build the application
-FROM maven:3.6.3-jdk-11-slim AS build
+FROM maven:3.9.5-eclipse-temurin-21-slim AS build
 WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline
 COPY src ./src
-RUN mvn package -DskipTests
+RUN mvn package
 
 # Use an official OpenJDK image to run the application
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:21-jre-slim
 WORKDIR /app
 COPY --from=build /app/target/flat_manager-0.0.1-SNAPSHOT.war .
 ENV PORT 8080


### PR DESCRIPTION
This change updates the project's Dockerfile to align with the Java 21 requirement specified in the pom.xml. It also ensures that the build process includes the execution of Maven tests, promoting better CI/CD practices within the containerized environment.

---
*PR created automatically by Jules for task [11369006627173685548](https://jules.google.com/task/11369006627173685548) started by @rowinskidamian*