### PR TITLE
Add GitHub Actions CI workflow for Maven

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,23 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean verify


### PR DESCRIPTION
This change adds a GitHub Actions workflow to the repository. The workflow is configured to:
- Run on pushes and pull requests to the `master` branch.
- Use Ubuntu as the runner OS.
- Set up Java 21 (Temurin distribution).
- Cache Maven dependencies to improve build times.
- Run `mvn -B clean verify` to build the project and execute all tests.

This ensures that the project is automatically built and tested in the GitHub environment.

---
*PR created automatically by Jules for task [1296017595095277313](https://jules.google.com/task/1296017595095277313) started by @rowinskidamian*