### PR TITLE
Add GitHub Action for GKE Cloud Run deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Build and Deploy to Cloud Run on GKE
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  GKE_CLUSTER: ${{ secrets.GKE_CLUSTER_NAME }}
+  GKE_ZONE: ${{ secrets.GKE_CLUSTER_ZONE }}
+  IMAGE: flat_manager
+  REGISTRY_PATH: gcr.io/${{ secrets.GCP_PROJECT_ID }} # Placeholder for registry path
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, Publish, and Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Build and Test with Maven
+      run: mvn clean test
+
+    - name: Authenticate to Google Cloud
+      uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Configure Docker
+      run: gcloud auth configure-docker --quiet
+
+    - name: Build and Push Docker image
+      run: |
+        docker build -t $REGISTRY_PATH/$IMAGE:$GITHUB_SHA .
+        docker push $REGISTRY_PATH/$IMAGE:$GITHUB_SHA
+
+    - name: Deploy to Cloud Run on GKE
+      uses: google-github-actions/deploy-cloudrun@v2
+      with:
+        service: ${{ env.IMAGE }}
+        image: ${{ env.REGISTRY_PATH }}/${{ env.IMAGE }}:${{ github.sha }}
+        # GKE specific settings
+        cluster: ${{ env.GKE_CLUSTER }}
+        cluster_location: ${{ env.GKE_ZONE }}
+        # Since it is GKE, we might need platform: gke if supported or defined by context
+        # The deploy-cloudrun action handles the platform via cluster/cluster_location inputs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Maven image to build the application
-FROM maven:3.6.3-jdk-11-slim AS build
+FROM maven:3.8.8-eclipse-temurin-21 AS build
 WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline
@@ -7,9 +7,9 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 # Use an official OpenJDK image to run the application
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=build /app/target/flat_manager-0.0.1-SNAPSHOT.war .
-ENV PORT 8080
+ENV PORT=8080
 EXPOSE 8080
 CMD ["java", "-jar", "flat_manager-0.0.1-SNAPSHOT.war"]


### PR DESCRIPTION
This change adds a CI/CD pipeline using GitHub Actions to automate the building, testing, and deployment of the Flat Manager application to Google Cloud Run on GKE.

Key modifications:
1. **Dockerfile Update**: The base images were updated from Java 11 to Java 21 (Eclipse Temurin) to support the Spring Boot 3.2.0 requirements and match the project's configuration.
2. **GitHub Actions Workflow**: A new workflow file `.github/workflows/deploy.yml` was created. It includes steps for:
    - Checking out the code.
    - Setting up JDK 21.
    - Running Maven tests.
    - Authenticating with Google Cloud.
    - Building and pushing the Docker image to a container registry.
    - Deploying the service to Cloud Run on GKE using the specified cluster and location.
3. **Branch Target**: The workflow is configured to trigger on pushes to the `master` branch.

Security note: The workflow relies on GitHub Secrets (`GCP_PROJECT_ID`, `GCP_SA_KEY`, `GKE_CLUSTER_NAME`, `GKE_CLUSTER_ZONE`) to manage sensitive credentials and environment-specific settings.

---
*PR created automatically by Jules for task [6808209798636847448](https://jules.google.com/task/6808209798636847448) started by @rowinskidamian*